### PR TITLE
Prevent $MTGY metric errors from halting init function

### DIFF
--- a/src/vuex/actions/index.js
+++ b/src/vuex/actions/index.js
@@ -28,21 +28,23 @@ export default {
 
       // Get MTGY info before having to connect wallet.
       // Allows dashboard data to be shown even if user does not connect wallet.
-      await Promise.all([
-        dispatch("getMtgyPriceUsd"),
-        dispatch("getMTGYCirculatingSupply"),
-        dispatch("getMTGYTotalSupply"),
-        dispatch("getMtgyTokenInfo"),
-        dispatch("getMtgyTokenChart"),
-        dispatch("getCurrentBlock"),
-      ]);
+      // Wrapped in try/catch so errors thrown here don't prevent finishing init.
+      try {
+        await Promise.all([
+          dispatch("getMtgyPriceUsd"),
+          dispatch("getMTGYCirculatingSupply"),
+          dispatch("getMTGYTotalSupply"),
+          dispatch("getMtgyTokenInfo"),
+          dispatch("getMtgyTokenChart"),
+          dispatch("getCurrentBlock"),
+        ]);
+      } catch (e) {
+        console.log("Error getting MTGY info.");
+      }
 
       if (!window.web3) {
-        return commit(
-          "SET_GLOBAL_ERROR",
-          new Error(
-            "Make sure you using a web3 enabled browser like Metamask, TrustWallet etc."
-          )
+        throw new Error(
+          "Make sure you using a web3 enabled browser like Metamask, TrustWallet etc."
         );
       }
       if (state.web3 && state.web3.isConnected && !reset) return;


### PR DESCRIPTION
If any of the endpoints where we get $MTGY info returns a `500` on initial load of the app, it breaks out of the init function and prevents the user from being able to connect their wallet. Since the logic for getting the $MTGY info is ultimately in the `refreshable` functionality, we can just ignore any errors getting this info on `init`.

![image](https://user-images.githubusercontent.com/2244987/131224022-92b32994-c56c-4796-a2a6-1c56131056e1.png)
