### PR TITLE
Correct KCC blocktime to 3 seconds

### DIFF
--- a/src/vuex/state/index.js
+++ b/src/vuex/state/index.js
@@ -144,7 +144,7 @@ export default {
         network_id: 1,
         explorer_url: "https://explorer.kcc.io/en",
         rpc_url: "https://rpc-mainnet.kcc.network",
-        blocks_per_day: 14400,
+        blocks_per_day: 28800,
         native_currency: {
           symbol: "KCS",
           name: "KCS",


### PR DESCRIPTION
The ETA for farm endings is off because of incorrect blocks_per_day setting. KCC blocks are generated every 3 seconds. Source: https://www.kcc.io/